### PR TITLE
ci: add codecov.yml with path-based ignores for tests/ and tools/

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,28 @@
+# Codecov configuration for FrigateRelay
+# Reference: https://docs.codecov.com/docs/codecov-yaml
+#
+# Why this file exists alongside the ReportGenerator -assemblyfilters in
+# Jenkinsfile: ReportGenerator filters by ASSEMBLY name, but Codecov
+# bookkeeping is path-based. Some cobertura XMLs include assemblies under
+# package names that don't match the assembly filter exactly, so the
+# tests/ and tools/ source paths still appeared on the Codecov dashboard.
+# The path-based ignore here is the durable fix and stays correct even
+# if the upstream coverage tooling changes its package-naming convention.
+
+ignore:
+  - "tests/**"
+  - "tools/**"
+
+coverage:
+  status:
+    project:
+      default:
+        # Allow a 1% drift before failing the project status check.
+        # Trivial coverage wiggles (e.g. a one-line refactor) shouldn't
+        # block PRs; substantive regressions still will.
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 1%


### PR DESCRIPTION
## Summary

The Jenkinsfile already passes `-assemblyfilters` to ReportGenerator to exclude `FrigateRelay.TestHelpers` and `FrigateRelay.MigrateConf` from the merged Cobertura.xml, but those rows are still appearing on the Codecov dashboard. Codecov's bookkeeping is path-based, not assembly-name-based, and the cobertura XMLs from MTP coverage include packages whose names don't map to the assembly filter cleanly.

A path-based `ignore:` at the Codecov ingestion layer is the durable fix:
- Independent of ReportGenerator filter syntax
- Survives upstream coverage-tool changes
- Single place to manage Codecov-side behavior

Also adds a 1% drift threshold to project + patch status checks so trivial coverage wiggles don't fail the PR status check.

## Test plan
- [ ] Merge → next Jenkins build uploads to Codecov
- [ ] Codecov dashboard for `main` no longer shows `tests/FrigateRelay.TestHelpers` or `tools/FrigateRelay.MigrateConf` rows
- [ ] Project coverage % reflects only `src/**`