### PR TITLE
fix(release): empty subscriptions list in smoke config

### DIFF
--- a/docker/appsettings.Smoke.json
+++ b/docker/appsettings.Smoke.json
@@ -4,12 +4,5 @@
     "Port": 1883,
     "Topic": "frigate/events"
   },
-  "Subscriptions": [
-    {
-      "Name": "Smoke",
-      "Camera": "test",
-      "Label": "person",
-      "Actions": []
-    }
-  ]
+  "Subscriptions": []
 }


### PR DESCRIPTION
## Summary

\`docker/appsettings.Smoke.json\` was declaring a \`'Smoke'\` subscription with \`\"Actions\": []\`. Phase 8's collect-all startup validator (\`ProfileResolver.cs:36\` — \`hasActions = sub.Actions.Count > 0\`) counts an empty Actions array as "no actions declared" and rejects:

> \`Subscription 'Smoke' must declare either 'Profile' or 'Actions'.\`

This crashes the host before the HTTP listener binds port 8080, so the smoke gate's \`/healthz\` poll times out for the full 30s window and \`release.yml\` fails before the multi-arch push step.

The smoke only needs the host to boot, connect to MQTT, and serve \`/healthz\` — no event routing required. Removing the broken subscription entirely lets \`ProfileResolver.Resolve\` iterate zero subscriptions and validation passes.

## What this unblocks

\`v1.0.0-rc1\` failed at the smoke gate. After this lands, I'll re-tag as \`v1.0.0-rc2\` (git tags are immutable on the remote — can't reuse \`-rc1\`) so release.yml fires again with the fixed smoke config.

## Test plan
- [x] CI passes on this PR.
- [ ] After merge, tag \`v1.0.0-rc2\`. release.yml smoke gate now returns 200 from /healthz; multi-arch push completes.