### PR TITLE
fix(host): expand Profile references at PostConfigure (#20)

### DIFF
--- a/src/FrigateRelay.Host/Configuration/HostSubscriptionsOptions.cs
+++ b/src/FrigateRelay.Host/Configuration/HostSubscriptionsOptions.cs
@@ -23,5 +23,13 @@ internal sealed record HostSubscriptionsOptions
     /// Gets the list of subscription rules. Defaults to an empty array when the configuration
     /// section is absent or contains no entries.
     /// </summary>
-    public IReadOnlyList<SubscriptionOptions> Subscriptions { get; init; } = Array.Empty<SubscriptionOptions>();
+    /// <remarks>
+    /// Settable (not <c>init</c>) so the <c>IPostConfigureOptions</c> registered in
+    /// <c>HostBootstrap</c> can replace the bound list with the profile-resolved version
+    /// (Profile references expanded into concrete Actions). Without that mutation,
+    /// runtime consumers see the raw bound list where <see cref="SubscriptionOptions.Profile"/>
+    /// is set and <see cref="SubscriptionOptions.Actions"/> is empty, which causes the
+    /// dispatcher's per-action loop to silently no-op.
+    /// </remarks>
+    public IReadOnlyList<SubscriptionOptions> Subscriptions { get; set; } = Array.Empty<SubscriptionOptions>();
 }

--- a/src/FrigateRelay.Host/FrigateRelay.Host.csproj
+++ b/src/FrigateRelay.Host/FrigateRelay.Host.csproj
@@ -9,11 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- appsettings.Local.json is an optional developer-only override; never committed. -->
-    <Content Include="appsettings.Local.json" CopyToOutputDirectory="PreserveNewest" Condition="Exists('appsettings.Local.json')" />
-  </ItemGroup>
-
-  <ItemGroup>
     <!-- Microsoft.Extensions.Hosting, Configuration.UserSecrets, and Caching.Memory are provided
          transitively by Microsoft.NET.Sdk.Web — explicit references here trigger NU1510
          (warnings-as-errors). Removed when SDK changed from Worker to Web (PLAN-1.1 Task 2). -->

--- a/src/FrigateRelay.Host/HostBootstrap.cs
+++ b/src/FrigateRelay.Host/HostBootstrap.cs
@@ -71,8 +71,18 @@ internal static class HostBootstrap
             .AddCheck<MqttHealthCheck>("mqtt-and-startup");
 
         // Host-scope services.
+        // PostConfigure expands SubscriptionOptions.Profile references into resolved
+        // Actions lists so EventPump's runtime read of IOptionsMonitor.CurrentValue
+        // sees fully-resolved subscriptions. Errors are re-surfaced by
+        // StartupValidation.ValidateAll (idempotent on already-resolved inputs); the
+        // local accumulator here is discarded.
         builder.Services.AddOptions<HostSubscriptionsOptions>()
-            .Bind(builder.Configuration);
+            .Bind(builder.Configuration)
+            .PostConfigure(opts =>
+            {
+                var resolveErrors = new List<string>();
+                opts.Subscriptions = ProfileResolver.Resolve(opts, resolveErrors);
+            });
 
         builder.Services.AddSingleton<IMemoryCache>(new MemoryCache(new MemoryCacheOptions()));
         builder.Services.AddSingleton<DedupeCache>();

--- a/tests/FrigateRelay.Host.Tests/Configuration/ProfileResolutionPostConfigureTests.cs
+++ b/tests/FrigateRelay.Host.Tests/Configuration/ProfileResolutionPostConfigureTests.cs
@@ -1,0 +1,73 @@
+using FluentAssertions;
+using FrigateRelay.Host.Configuration;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace FrigateRelay.Host.Tests.Configuration;
+
+/// <summary>
+/// Regression tests for issue #20 — confirms <c>HostBootstrap.ConfigureServices</c>
+/// registers an <c>IPostConfigureOptions&lt;HostSubscriptionsOptions&gt;</c> that runs
+/// <c>ProfileResolver.Resolve</c> so runtime consumers (EventPump) see expanded
+/// <see cref="SubscriptionOptions.Actions"/> on profile-based subscriptions.
+/// </summary>
+/// <remarks>
+/// Pre-fix behavior (rc1, rc2): every profile-based subscription matched events correctly
+/// but iterated an empty <c>Actions</c> list in the dispatch loop, silently dropping all
+/// actions. The defect was missed because <see cref="ProfileResolver"/> was already covered
+/// by unit tests in isolation, and integration tests used inline-Actions configs that
+/// never exercised the profile-resolution path through DI.
+/// </remarks>
+[TestClass]
+public sealed class ProfileResolutionPostConfigureTests
+{
+    [TestMethod]
+    public void HostBootstrap_ProfileBasedSubscription_ExpandsToConcreteActions()
+    {
+        var builder = WebApplication.CreateBuilder(Array.Empty<string>());
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["FrigateMqtt:Server"] = "localhost",
+            ["Profiles:Standard:Actions:0:Plugin"] = "BlueIris",
+            ["Profiles:Standard:Actions:1:Plugin"] = "Pushover",
+            ["Subscriptions:0:Name"] = "Drive",
+            ["Subscriptions:0:Camera"] = "driveway",
+            ["Subscriptions:0:Label"] = "person",
+            ["Subscriptions:0:Profile"] = "Standard",
+        });
+
+        HostBootstrap.ConfigureServices(builder);
+        using var app = builder.Build();
+
+        var monitor = app.Services.GetRequiredService<IOptionsMonitor<HostSubscriptionsOptions>>();
+        var sub = monitor.CurrentValue.Subscriptions.Should().ContainSingle().Which;
+
+        sub.Profile.Should().BeNull("ProfileResolver clears Profile after expansion");
+        sub.Actions.Should().HaveCount(2);
+        sub.Actions.Select(a => a.Plugin).Should().Equal("BlueIris", "Pushover");
+    }
+
+    [TestMethod]
+    public void HostBootstrap_InlineActionsSubscription_PreservedUnchanged()
+    {
+        var builder = WebApplication.CreateBuilder(Array.Empty<string>());
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["FrigateMqtt:Server"] = "localhost",
+            ["Subscriptions:0:Name"] = "Drive",
+            ["Subscriptions:0:Camera"] = "driveway",
+            ["Subscriptions:0:Label"] = "person",
+            ["Subscriptions:0:Actions:0:Plugin"] = "BlueIris",
+        });
+
+        HostBootstrap.ConfigureServices(builder);
+        using var app = builder.Build();
+
+        var monitor = app.Services.GetRequiredService<IOptionsMonitor<HostSubscriptionsOptions>>();
+        var sub = monitor.CurrentValue.Subscriptions.Should().ContainSingle().Which;
+
+        sub.Actions.Should().ContainSingle().Which.Plugin.Should().Be("BlueIris");
+    }
+}


### PR DESCRIPTION
## Summary

- `ProfileResolver.Resolve` now runs at PostConfigure time and replaces the bound `HostSubscriptionsOptions.Subscriptions` list with the profile-expanded version, so `EventPump`'s runtime read of `IOptionsMonitor.CurrentValue` sees concrete `Actions` for every profile-based subscription.
- New regression test `ProfileResolutionPostConfigureTests` exercises the real `HostBootstrap.ConfigureServices` wiring (not just the resolver in isolation), so a future change can't silently regress by removing the `.PostConfigure(...)` call.
- Drive-by: removed the redundant explicit `<Content Include="appsettings.Local.json">` from the host csproj that was duplicating the Web SDK's auto-include and triggering NETSDK1022 once the file existed on disk.

Closes #20.

## Background

rc1 and rc2 are tainted by this defect. With a `Profiles + Subscription.Profile` config, the host appeared healthy, the matcher logged `Matched event:` correctly, and then nothing fired — `EventPump`'s `foreach (var entry in sub.Actions)` iterated zero times because `Actions` was empty. No `Enqueued action=` log, no plugin call. Pre-existing tests covered `ProfileResolver` in isolation but not the DI wiring through `IPostConfigureOptions → IOptionsMonitor → EventPump`.

Verified working against the operator's live Frigate 0.17.1 broker today: zone-entry person events now drive BlueIris HTTP trigger + FrigateSnapshot fetch + CodeProject.AI detection (logged 77ms YOLOv5 detect) + Pushover notification, end-to-end, on every camera in the operator's config (Driveway, Backyard, Garage, Front Door Porch, Front Yard, etc).

## Test plan

- [x] `dotnet build FrigateRelay.sln -c Release` clean (0 warnings, 0 errors).
- [x] `dotnet run --project tests/FrigateRelay.Host.Tests -c Release` — 105/105 pass (was 103, +2 new regression tests).
- [x] Live verification on operator's Unraid + Frigate 0.17.1 deployment for ≥6 distinct cameras over ~30 minutes.
- [x] PR CI gate (ci.yml) on ubuntu-latest + windows-latest.
- [x] Jenkins coverage build.

## v1.0.0 path

After merge, tag `v1.0.0-rc3`. release.yml smoke-gates against `/healthz` then pushes multi-arch to GHCR. Operator pulls rc3 to Unraid, parity window resumes for ≥48h.

🤖 Generated with [Claude Code](https://claude.com/claude-code)