### PR TITLE
test: opt-in real-broker integration profile (refs #17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `tests/FrigateRelay.IntegrationTests.RealBroker/` — opt-in integration-test project that runs against an operator-supplied MQTT broker rather than the in-process Testcontainers Mosquitto. Tests self-skip via `Assert.Inconclusive` unless `FRIGATERELAY_TEST_REAL_BROKER=1` is set; broker host/port and optional credentials come from `FRIGATERELAY_TEST_MQTT_HOST`/`_PORT`/`_USERNAME`/`_PASSWORD`. Topic prefix is `frigaterelay-test/<guid>/events` (never `frigate/events`) so a misconfigured test cannot trigger production action plugins. The project is not auto-discovered by `.github/scripts/run-tests.sh` — invoke it explicitly via `dotnet run --project tests/FrigateRelay.IntegrationTests.RealBroker`. See CONTRIBUTING.md for the operator run-book. Closes the harness portion of #17; the silent-SUBACK regression test (acceptance criterion 3) lands with the #16 fix in a follow-up PR.
+
 ## [1.0.0] — 2026-05-03
 
 Initial public release. 1:1 functional parity with the legacy `FrigateMQTTProcessingService` verified via a 24-hour live A/B window across all production cameras with zero missed alerts and zero spurious alerts — see `docs/parity-report.md`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,22 @@ dotnet run --project tests/FrigateRelay.Host.Tests -c Release -- --filter "Plugi
 
 **Integration tests** require Docker (Testcontainers spins up Mosquitto and WireMock stubs automatically).
 
+**Real-broker integration tests (opt-in)** live in `tests/FrigateRelay.IntegrationTests.RealBroker/` and run against an operator-supplied MQTT broker — useful as a final confidence check before tagging a release. They are **not** auto-discovered by `run-tests.sh`, and individual tests self-skip when the opt-in env var is not set, so neither CI nor a casual `dotnet run` will accidentally try to reach a broker that isn't there.
+
+To run them against your own broker (host must be reachable from the machine running the test):
+
+```bash
+export FRIGATERELAY_TEST_REAL_BROKER=1
+export FRIGATERELAY_TEST_MQTT_HOST=mosquitto.lan
+export FRIGATERELAY_TEST_MQTT_PORT=1883          # optional; default 1883
+export FRIGATERELAY_TEST_MQTT_USERNAME=relay     # optional
+export FRIGATERELAY_TEST_MQTT_PASSWORD=secret    # optional
+
+dotnet run --project tests/FrigateRelay.IntegrationTests.RealBroker -c Release
+```
+
+The tests publish on a unique-per-run topic under `frigaterelay-test/<guid>/events` (never on `frigate/events`), so a misconfigured run cannot trigger production action plugins listening on the real Frigate topic. Each test also uses a unique-per-run MQTT ClientId so two concurrent runs don't kick each other off the broker.
+
 ## Coding standards
 
 The full set of architecture invariants is in `CLAUDE.md` — treat it as authoritative. Contributor-relevant highlights:

--- a/FrigateRelay.sln
+++ b/FrigateRelay.sln
@@ -49,6 +49,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FrigateRelay.MigrateConf", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FrigateRelay.MigrateConf.Tests", "tests\FrigateRelay.MigrateConf.Tests\FrigateRelay.MigrateConf.Tests.csproj", "{32DFD307-D93B-4794-9D36-B5EF1208C361}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FrigateRelay.IntegrationTests.RealBroker", "tests\FrigateRelay.IntegrationTests.RealBroker\FrigateRelay.IntegrationTests.RealBroker.csproj", "{C15C8832-0CFD-4A10-860C-2D8243BECD67}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -287,6 +289,18 @@ Global
 		{32DFD307-D93B-4794-9D36-B5EF1208C361}.Release|x64.Build.0 = Release|Any CPU
 		{32DFD307-D93B-4794-9D36-B5EF1208C361}.Release|x86.ActiveCfg = Release|Any CPU
 		{32DFD307-D93B-4794-9D36-B5EF1208C361}.Release|x86.Build.0 = Release|Any CPU
+		{C15C8832-0CFD-4A10-860C-2D8243BECD67}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C15C8832-0CFD-4A10-860C-2D8243BECD67}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C15C8832-0CFD-4A10-860C-2D8243BECD67}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C15C8832-0CFD-4A10-860C-2D8243BECD67}.Debug|x64.Build.0 = Debug|Any CPU
+		{C15C8832-0CFD-4A10-860C-2D8243BECD67}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C15C8832-0CFD-4A10-860C-2D8243BECD67}.Debug|x86.Build.0 = Debug|Any CPU
+		{C15C8832-0CFD-4A10-860C-2D8243BECD67}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C15C8832-0CFD-4A10-860C-2D8243BECD67}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C15C8832-0CFD-4A10-860C-2D8243BECD67}.Release|x64.ActiveCfg = Release|Any CPU
+		{C15C8832-0CFD-4A10-860C-2D8243BECD67}.Release|x64.Build.0 = Release|Any CPU
+		{C15C8832-0CFD-4A10-860C-2D8243BECD67}.Release|x86.ActiveCfg = Release|Any CPU
+		{C15C8832-0CFD-4A10-860C-2D8243BECD67}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -311,5 +325,6 @@ Global
 		{F995253A-EFEA-44C0-88EB-6BF2CF4BEA96} = {5D20AA90-6969-D8BD-9DCD-8634F4692FDA}
 		{9D1D5315-0F8B-4932-9522-0B56F8D8D8EE} = {07C2787E-EAC7-C090-1BA3-A61EC2A24D84}
 		{32DFD307-D93B-4794-9D36-B5EF1208C361} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+		{C15C8832-0CFD-4A10-860C-2D8243BECD67} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 EndGlobal

--- a/src/FrigateRelay.Host/FrigateRelay.Host.csproj
+++ b/src/FrigateRelay.Host/FrigateRelay.Host.csproj
@@ -64,6 +64,7 @@
   <ItemGroup>
     <InternalsVisibleTo Include="FrigateRelay.Host.Tests" />
     <InternalsVisibleTo Include="FrigateRelay.IntegrationTests" />
+    <InternalsVisibleTo Include="FrigateRelay.IntegrationTests.RealBroker" />
     <!-- Required by NSubstitute to create proxy substitutes for internal interfaces/classes. -->
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>

--- a/tests/FrigateRelay.IntegrationTests.RealBroker/FrigateRelay.IntegrationTests.RealBroker.csproj
+++ b/tests/FrigateRelay.IntegrationTests.RealBroker/FrigateRelay.IntegrationTests.RealBroker.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+    <EnableMSTestRunner>true</EnableMSTestRunner>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+    <TestingPlatformShowTestsFailure>true</TestingPlatformShowTestsFailure>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MSTest" Version="4.2.1" />
+    <PackageReference Include="FluentAssertions" Version="6.12.2" />
+    <PackageReference Include="MQTTnet" Version="5.1.0.1559" />
+    <PackageReference Include="WireMock.Net" Version="2.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\FrigateRelay.Host\FrigateRelay.Host.csproj" />
+    <ProjectReference Include="..\..\src\FrigateRelay.Plugins.BlueIris\FrigateRelay.Plugins.BlueIris.csproj" />
+    <ProjectReference Include="..\..\src\FrigateRelay.Sources.FrigateMqtt\FrigateRelay.Sources.FrigateMqtt.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/FrigateRelay.IntegrationTests.RealBroker/RealBrokerEnvironment.cs
+++ b/tests/FrigateRelay.IntegrationTests.RealBroker/RealBrokerEnvironment.cs
@@ -1,0 +1,84 @@
+using System.Globalization;
+
+namespace FrigateRelay.IntegrationTests.RealBroker;
+
+/// <summary>
+/// Operator-supplied environment for the opt-in real-broker test profile.
+/// Tests in this project self-skip via <see cref="SkipIfNotEnabled"/> unless
+/// <c>FRIGATERELAY_TEST_REAL_BROKER=1</c> is set, so CI (which never sets it)
+/// reports these as Inconclusive/Skipped and never times out connecting to
+/// a non-existent broker.
+/// </summary>
+internal static class RealBrokerEnvironment
+{
+    public const string OptInVar = "FRIGATERELAY_TEST_REAL_BROKER";
+    public const string HostVar = "FRIGATERELAY_TEST_MQTT_HOST";
+    public const string PortVar = "FRIGATERELAY_TEST_MQTT_PORT";
+    public const string UsernameVar = "FRIGATERELAY_TEST_MQTT_USERNAME";
+    public const string PasswordVar = "FRIGATERELAY_TEST_MQTT_PASSWORD";
+
+    /// <summary>
+    /// Topic prefix the real-broker tests publish under. Deliberately distinct
+    /// from Frigate's <c>frigate/events</c> so a misconfigured test cannot
+    /// trigger production action plugins listening on the real topic.
+    /// </summary>
+    public const string TestTopicPrefix = "frigaterelay-test";
+
+    public static bool IsEnabled =>
+        string.Equals(Environment.GetEnvironmentVariable(OptInVar), "1", StringComparison.Ordinal);
+
+    /// <summary>
+    /// Marks the calling test Inconclusive (Skipped) when the real-broker
+    /// profile is not enabled. Call as the first line of every test method.
+    /// </summary>
+    public static void SkipIfNotEnabled()
+    {
+        if (!IsEnabled)
+        {
+            Assert.Inconclusive(
+                $"Real-broker tests are opt-in. Set {OptInVar}=1 plus {HostVar} (and optionally " +
+                $"{PortVar}, {UsernameVar}, {PasswordVar}) to enable. See CONTRIBUTING.md.");
+        }
+    }
+
+    /// <summary>
+    /// Returns the operator-configured broker endpoint. Throws if the opt-in
+    /// flag is set but required vars are missing — fail-fast with a clear
+    /// diagnostic rather than time out connecting to nothing.
+    /// </summary>
+    public static (string Host, int Port) GetBroker()
+    {
+        var host = Environment.GetEnvironmentVariable(HostVar);
+        if (string.IsNullOrWhiteSpace(host))
+            throw new InvalidOperationException($"{HostVar} must be set when {OptInVar}=1");
+
+        var portRaw = Environment.GetEnvironmentVariable(PortVar);
+        if (string.IsNullOrWhiteSpace(portRaw))
+            return (host, 1883);
+
+        if (!int.TryParse(portRaw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var port))
+            throw new InvalidOperationException($"{PortVar} must be an integer; got '{portRaw}'");
+
+        return (host, port);
+    }
+
+    public static (string? Username, string? Password) GetCredentials()
+        => (
+            Environment.GetEnvironmentVariable(UsernameVar),
+            Environment.GetEnvironmentVariable(PasswordVar));
+
+    /// <summary>
+    /// Builds a unique-per-run topic under <see cref="TestTopicPrefix"/>. Two
+    /// concurrent test runs against the same broker (or a leftover retained
+    /// message from a prior run) cannot cross-contaminate.
+    /// </summary>
+    public static string NewIsolatedTopic()
+        => $"{TestTopicPrefix}/{Guid.NewGuid():N}/events";
+
+    /// <summary>
+    /// Builds a unique ClientId so two concurrent test runs against the same
+    /// broker do not race each other (the same foot-gun #18 documents).
+    /// </summary>
+    public static string NewIsolatedClientId()
+        => $"frigaterelay-test-{Guid.NewGuid():N}";
+}

--- a/tests/FrigateRelay.IntegrationTests.RealBroker/RealBrokerHappyPathTests.cs
+++ b/tests/FrigateRelay.IntegrationTests.RealBroker/RealBrokerHappyPathTests.cs
@@ -1,0 +1,144 @@
+using System.Globalization;
+using FluentAssertions;
+using FrigateRelay.Host;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MQTTnet;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
+
+namespace FrigateRelay.IntegrationTests.RealBroker;
+
+/// <summary>
+/// End-to-end smoke against an operator-supplied real Mosquitto (or other
+/// MQTT 3.1.1/5.0) broker. Proves the full pipeline — FrigateRelay subscribes,
+/// Frigate-shaped event arrives via the broker, BlueIris action fires — works
+/// against real broker behaviour (TCP, real CONNACK/SUBACK round-trips, real
+/// keepalive timing) rather than the in-process Testcontainers Mosquitto used
+/// by the default integration suite.
+///
+/// Skipped on CI by default — see <see cref="RealBrokerEnvironment"/>.
+/// </summary>
+[TestClass]
+public sealed class RealBrokerHappyPathTests
+{
+    [TestMethod]
+    [Timeout(60_000)]
+    public async Task RealBroker_PublishSubscribe_BlueIrisActionFires()
+    {
+        RealBrokerEnvironment.SkipIfNotEnabled();
+
+        var (brokerHost, brokerPort) = RealBrokerEnvironment.GetBroker();
+        var (brokerUser, brokerPass) = RealBrokerEnvironment.GetCredentials();
+        var topic = RealBrokerEnvironment.NewIsolatedTopic();
+        var hostClientId = RealBrokerEnvironment.NewIsolatedClientId();
+
+        // WireMock BlueIris stub on an ephemeral local port.
+        using var wireMock = WireMockServer.Start();
+        wireMock.Given(Request.Create()
+                .UsingGet()
+                .WithPath("/admin")
+                .WithParam("camera", "front")
+                .WithParam("trigger", "1"))
+            .RespondWith(Response.Create().WithStatusCode(200));
+
+        var config = new Dictionary<string, string?>
+        {
+            ["BlueIris:TriggerUrlTemplate"] = $"{wireMock.Urls[0]}/admin?camera={{camera}}&trigger=1",
+            ["BlueIris:RequestTimeout"] = "00:00:05",
+            ["FrigateMqtt:Server"] = brokerHost,
+            ["FrigateMqtt:Port"] = brokerPort.ToString(CultureInfo.InvariantCulture),
+            ["FrigateMqtt:Topic"] = topic,
+            ["FrigateMqtt:ClientId"] = hostClientId,
+            ["Subscriptions:0:Name"] = "RealBrokerSmoke",
+            ["Subscriptions:0:Camera"] = "front",
+            ["Subscriptions:0:Label"] = "person",
+            ["Subscriptions:0:Actions:0:Plugin"] = "BlueIris",
+        };
+        if (!string.IsNullOrEmpty(brokerUser))
+            config["FrigateMqtt:Username"] = brokerUser;
+        if (!string.IsNullOrEmpty(brokerPass))
+            config["FrigateMqtt:Password"] = brokerPass;
+
+        var builder = WebApplication.CreateBuilder(Array.Empty<string>());
+        builder.Configuration.AddInMemoryCollection(config);
+
+        HostBootstrap.ConfigureServices(builder);
+
+        using var app = builder.Build();
+        HostBootstrap.ValidateStartup(app.Services);
+
+        await app.StartAsync().ConfigureAwait(false);
+
+        // Wait for the host to subscribe before publishing — same race-avoidance
+        // pattern as MqttToBlueIrisSliceTests.
+        var hostMqttClient = app.Services.GetRequiredService<IMqttClient>();
+        var connectDeadline = DateTime.UtcNow.AddSeconds(15);
+        while (!hostMqttClient.IsConnected && DateTime.UtcNow < connectDeadline)
+            await Task.Delay(50).ConfigureAwait(false);
+        hostMqttClient.IsConnected.Should().BeTrue(
+            "host MQTT client must connect to the real broker within 15s");
+
+        IMqttClient? publisher = null;
+        try
+        {
+            var payload = """
+                {
+                  "type": "new",
+                  "before": null,
+                  "after": {
+                    "id": "ev-realbroker-001",
+                    "camera": "front",
+                    "label": "person",
+                    "stationary": false,
+                    "false_positive": false,
+                    "score": 0.91,
+                    "start_time": 1745558400.0,
+                    "current_zones": ["driveway"],
+                    "entered_zones": ["driveway"]
+                  }
+                }
+                """;
+
+            var factory = new MqttClientFactory();
+            publisher = factory.CreateMqttClient();
+            var publisherOptions = new MqttClientOptionsBuilder()
+                .WithClientId(RealBrokerEnvironment.NewIsolatedClientId() + "-pub")
+                .WithTcpServer(brokerHost, brokerPort);
+            if (!string.IsNullOrEmpty(brokerUser))
+                publisherOptions = publisherOptions.WithCredentials(brokerUser, brokerPass);
+
+            await publisher.ConnectAsync(publisherOptions.Build()).ConfigureAwait(false);
+            await publisher.PublishStringAsync(topic, payload).ConfigureAwait(false);
+
+            var deadline = DateTime.UtcNow.AddSeconds(15);
+            while (DateTime.UtcNow < deadline)
+            {
+                if (wireMock.LogEntries.Any()) break;
+                await Task.Delay(100).ConfigureAwait(false);
+            }
+
+            var matchingRequests = wireMock.FindLogEntries(
+                Request.Create()
+                    .UsingGet()
+                    .WithPath("/admin")
+                    .WithParam("camera", "front")).ToList();
+            matchingRequests.Should().HaveCount(1,
+                "exactly one BlueIris trigger should fire for one matched Frigate event " +
+                "delivered via the real broker");
+        }
+        finally
+        {
+            if (publisher is not null)
+            {
+                if (publisher.IsConnected)
+                    await publisher.DisconnectAsync().ConfigureAwait(false);
+                publisher.Dispose();
+            }
+            await app.StopAsync().ConfigureAwait(false);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds `tests/FrigateRelay.IntegrationTests.RealBroker/` — an opt-in integration-test project that runs FrigateRelay against an operator-supplied MQTT broker rather than the in-process Testcontainers Mosquitto used by the default suite. Useful as a final confidence check before tagging a release, and as the harness the upcoming MQTT-robustness PR (#16/#18/#19) will write its regression tests against.

## Design choices

- **Self-skip via `Assert.Inconclusive`** unless `FRIGATERELAY_TEST_REAL_BROKER=1` is set. An ad-hoc `dotnet run --project tests/FrigateRelay.IntegrationTests.RealBroker` without the env var reports the test as Skipped (with a clear message about which env vars to set), rather than hanging on a connect attempt to nothing.
- **csproj filename ends in `.RealBroker.csproj`, not `.Tests.csproj`**. `.github/scripts/run-tests.sh` discovers via `find tests -maxdepth 2 -name '*Tests.csproj'`, so this project is intentionally **not** auto-discovered. CI never sees it. Operators run it explicitly. This matches the issue's "skips on CI by default" requirement at the project-discovery layer in addition to the per-test self-skip.
- **Per-run isolation.** Every test allocates a unique topic under `frigaterelay-test/<guid>/events` (never `frigate/events`) and a unique MQTT ClientId, so a misconfigured run cannot trigger production action plugins listening on the real Frigate topic, and two concurrent runs against the same broker cannot kick each other off (the same foot-gun #18 documents).

## What ships in this PR vs the next

This PR ships:
- The harness (`RealBrokerEnvironment.cs` env-var helper)
- One happy-path test: publish a Frigate event via the real broker, FrigateRelay subscribes and matches it, BlueIris WireMock stub fires exactly once
- `CONTRIBUTING.md` operator run-book section
- `CHANGELOG.md` `[Unreleased]` entry

The **silent-SUBACK regression test** (issue #17's acceptance criterion 3 — "at least one test that would have failed against the silent-SUBACK behaviour from #16") deliberately lands with the **#16 fix** in the next PR. Reason: a test that exercises silent-SUBACK detection only passes once the detection code exists, so coupling test+fix in the same PR avoids a transient red on main between merges. Issue #17 stays open until the #16 PR closes both.

## Out of scope

Caught while looking at the BlueIris plugin source — the README and `docker/.env.example` document several env vars that don't actually bind to anything (`BLUEIRIS__BASEURL`, `BLUEIRIS__USERNAME`, `BLUEIRIS__PASSWORD`) and one mistyped one (`PUSHOVER__APITOKEN` should be `APPTOKEN`). Filed as **#24** for a separate small docs PR — keeping this branch focused.

## Test plan

- [x] `dotnet build FrigateRelay.sln -c Release` — 0 warnings, 0 errors
- [x] `bash .github/scripts/run-tests.sh` — full suite green (210 tests across 9 projects); the new project is not auto-discovered (intentional)
- [x] `dotnet run --project tests/FrigateRelay.IntegrationTests.RealBroker -c Release` (no env var) — reports Skipped, exits 0
- [x] (manual, post-merge) `FRIGATERELAY_TEST_REAL_BROKER=1 FRIGATERELAY_TEST_MQTT_HOST=<host> dotnet run --project ...` against operator's broker — happy-path test passes

Refs #17. Closes the harness portion only; #17 remains open until #16's PR adds the silent-SUBACK regression test.