### PR TITLE
fix: eviction log reads from DispatchItem, not closure (ID-29)

### DIFF
--- a/.shipyard/ISSUES.md
+++ b/.shipyard/ISSUES.md
@@ -483,11 +483,14 @@ Implemented Option 1: `ActionEntryTypeConverter : TypeConverter` decorating `Act
 
 ---
 
-### ID-29: Eviction-callback log captures stale `plugin.Name` from loop variable
+### ID-29: Eviction-callback log captures stale `plugin.Name` from loop variable  *[CLOSED 2026-05-06]*
 
 **Source:** reviewer (Phase 13 REVIEW-1.1, 2026-05-04)
 **Severity:** Low (log-only; counter tags unaffected)
-**Status:** Open
+**Status:** **Closed** (hotfix branch `hotfix/29-eviction-log-staleness`, v1.1.1)
+
+**Resolution:**
+One-line swap at `ChannelActionDispatcher.cs:101` — `plugin.Name` → `evicted.Plugin.Name`. The log message's `Action` field now reads from the same source as the counter tags (the evicted `DispatchItem` itself), eliminating the closure-capture staleness window. No test added — the bug surfaces only under queued-eviction edge cases that are difficult to deterministically reproduce in unit tests; the fix is mechanical and preserves the existing log-line shape.
 
 **Description:**
 At `src/FrigateRelay.Host/Dispatch/ChannelActionDispatcher.cs:100–101`, the `Channel.CreateBounded` eviction callback captures `plugin` from the surrounding `foreach (var plugin in plugins)` loop. The post-PLAN-1.1 code is:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `ChannelActionDispatcher` eviction-callback log now reads the action name from the evicted `DispatchItem` rather than the surrounding `foreach` loop variable. Previously, in queued-eviction edge cases, the log message's `Action` field could refer to a different plugin than the one whose item was actually dropped — counter tags were already correct (sourced from `evicted` per CONTEXT-13 OQ-2); the log line is now consistent with them. ID-29.
+
 ## [1.1.0] — 2026-05-04
 
 Observability + structural cleanup. All counters on `Meter "FrigateRelay"` now emit structured tags so operators can pivot a Grafana dashboard by camera, subscription, action, validator, and component. Ships a complete reference observability stack (OTel Collector + Prometheus + Grafana, plus a standalone Seq stack for logs) and a full operator guide. Closes the v1.0.2 → v1.0.3 P0 root cause structurally by collapsing `BlueIrisUrlTemplate` to a thin wrapper around `EventTokenTemplate`.

--- a/src/FrigateRelay.Host/Dispatch/ChannelActionDispatcher.cs
+++ b/src/FrigateRelay.Host/Dispatch/ChannelActionDispatcher.cs
@@ -98,7 +98,7 @@ internal sealed class ChannelActionDispatcher : IActionDispatcher, IHostedServic
             var channel = Channel.CreateBounded<DispatchItem>(channelOptions, evicted =>
             {
                 DispatcherDiagnostics.IncrementDrops(evicted, "channel_full");
-                LogDropped(_logger, evicted.Context.EventId, plugin.Name, capacity, null);
+                LogDropped(_logger, evicted.Context.EventId, evicted.Plugin.Name, capacity, null);
             });
 
             _channels[plugin] = channel;


### PR DESCRIPTION
## Summary

- `ChannelActionDispatcher` bounded-channel eviction callback closed over the surrounding `foreach (var plugin in plugins)` loop variable. Counter tags were already correct (sourced from `evicted`); the log line is now consistent with them.
- One-line swap: `plugin.Name` → `evicted.Plugin.Name` at `ChannelActionDispatcher.cs:101`.
- Pre-existing closure-capture pattern surfaced during Phase 13 PLAN-1.1 review; deliberately deferred to keep that PR's scope tight. Tracked as ID-29 in `.shipyard/ISSUES.md`, now closed.
- CHANGELOG `[Unreleased]` records the fix for the next release tag.

## Why no test

The bug surfaces only under queued-eviction edge cases that are difficult to deterministically reproduce in unit tests — `Channel.CreateBounded` does not expose hooks to schedule a drop after the dispatcher's `foreach` has advanced. The fix is mechanical and preserves the existing log-line shape, so the regression risk is low and the value of a brittle timing-dependent test is lower.

## Test plan

- [x] `dotnet build FrigateRelay.sln -c Release` — 0 warnings, 0 errors
- [x] `bash .github/scripts/run-tests.sh --skip-integration` — 242/242 across 8 projects (no count change; mechanical fix)
- [ ] Operator validation: with structured logs aimed at Seq, eviction events under sustained load no longer show `action` mismatched against the dropped item's actual target

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed eviction logging to correctly identify which item was removed from the queue instead of displaying potentially incorrect information in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->